### PR TITLE
Add GitLab CI Capabilities

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+docker-build:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+  script:
+    - |
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
+        tag=""
+        echo "Running on default branch '$CI_DEFAULT_BRANCH': tag = 'latest'"
+      else
+        tag=":$CI_COMMIT_REF_SLUG"
+        echo "Running on branch '$CI_COMMIT_BRANCH': tag = $tag"
+      fi
+    - docker build --pull -t "$CI_REGISTRY_IMAGE${tag}" .
+    - docker push "$CI_REGISTRY_IMAGE${tag}"
+  rules:
+    - if: $CI_COMMIT_BRANCH
+      exists:
+        - Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt && apt-get update -y && apt-get install curl jq -y
+
+COPY . /usr/src/app
+
+CMD ["echo", "This is a 'Purpose-Built Container', It is not meant to be ran this way. Run this in a CI Pipeline."]

--- a/example.gitlab-ci.yml
+++ b/example.gitlab-ci.yml
@@ -1,0 +1,17 @@
+# This is an example file
+# Of how to run ess-gitlab in a GitLab CI pipeline.
+# Configure and control the execution of ess-gitlab with the variables.
+
+ess-gitlab-check:
+    image: registry.gitlab.com/<YOUR NAMESPACE>/ess-gitlab
+    stage: build
+    variables:
+        GIT_STRATEGY: clone
+        GITLAB_URL: 'https://gitlab.com'
+        ESS_MODE: 'baseline'
+        ESS_CHECK: 'project'
+        ESS_BASELINE: '/usr/src/app/baselines/default.yml'
+        ESS_GITLAB_ID: '$CI_PROJECT_PATH'
+        ESS_GITLAB_TOKEN: '<DO NOT ADD A TOKEN HERE. ADD IT TO YOUR GITLAB ENVIRONMENT SETTINGS>'
+    script:
+        - /usr/src/app/ess-gitlab.py --gitlab_url $GITLAB_URL --mode $ESS_MODE --check $ESS_CHECK --baseline $ESS_BASELINE --id $ESS_GITLAB_ID --gitlab_token $ESS_GITLAB_TOKEN --jsonprint


### PR DESCRIPTION
## Description
This PR adds the files necessary to enable GitLab CI, as well as dockerize the ess-gitlab tool for operation in a CI Pipeline. GitLab CI best practices state that any/all third-party tools be in a container and ran as a pipeline. This PR does this. In addition, this PR includes an example of how to run the newly built container as part of a pipeline.

## Why does this matter?
With the advent of GitLab Compliance Pipelines, having ess-gitlab containerized, with a CI Job. Administrators of GitLab can use the CI Job and GitLab-ESS to do per-project checking and prevent the user's pipeline from continuing execution if that individual project does not abide by the GitLab Settings defined in the baseline definition file.

In the future it would be great to add alerting. But I suspect that is beyond the scope of this project's purpose.